### PR TITLE
No longer prefix verilog package identifiers with veryl project names

### DIFF
--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -2304,11 +2304,6 @@ impl VerylWalker for Emitter {
     fn package_declaration(&mut self, arg: &PackageDeclaration) {
         self.package(&arg.package);
         self.space(1);
-        // if let Ok(symbol) = symbol_table::resolve(arg.identifier.as_ref()) {
-        //     if let Some(symbol) = symbol.found {
-        //         self.str(&format!("{}_", symbol.namespace).replace("::", "_"));
-        //     }
-        // }
         self.identifier(&arg.identifier);
         self.token_will_push(&arg.l_brace.l_brace_token.replace(";"));
         for (i, x) in arg.package_declaration_list.iter().enumerate() {

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -2304,11 +2304,11 @@ impl VerylWalker for Emitter {
     fn package_declaration(&mut self, arg: &PackageDeclaration) {
         self.package(&arg.package);
         self.space(1);
-        if let Ok(symbol) = symbol_table::resolve(arg.identifier.as_ref()) {
-            if let Some(symbol) = symbol.found {
-                self.str(&format!("{}_", symbol.namespace).replace("::", "_"));
-            }
-        }
+        // if let Ok(symbol) = symbol_table::resolve(arg.identifier.as_ref()) {
+        //     if let Some(symbol) = symbol.found {
+        //         self.str(&format!("{}_", symbol.namespace).replace("::", "_"));
+        //     }
+        // }
         self.identifier(&arg.identifier);
         self.token_will_push(&arg.l_brace.l_brace_token.replace(";"));
         for (i, x) in arg.package_declaration_list.iter().enumerate() {


### PR DESCRIPTION
This is in order to deal with the issue I raised https://github.com/dalance/veryl/issues/324

I am not sure entirely why module and package names are prefixed with project names --- perhaps because verilog has no real module system or namespace system.  If that's the goal, then `emitter.rs` should be changed to also prefix package identifiers in `scoped_identifier`.  

