### PR TITLE
Cycle check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "daggy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91a9304e55e9d601a39ae4deaba85406d5c0980e106f65afcf0460e9af1e7602"
+dependencies = [
+ "petgraph",
+]
+
+[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +931,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -2711,6 +2726,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.0.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4195,6 +4220,7 @@ name = "veryl-analyzer"
 version = "0.5.5"
 dependencies = [
  "Inflector",
+ "daggy",
  "miette",
  "strnum_bitwidth",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4220,6 +4220,7 @@ name = "veryl-analyzer"
 version = "0.5.5"
 dependencies = [
  "Inflector",
+ "bimap",
  "daggy",
  "miette",
  "strnum_bitwidth",

--- a/crates/analyzer/Cargo.toml
+++ b/crates/analyzer/Cargo.toml
@@ -19,6 +19,7 @@ strnum_bitwidth = {workspace = true}
 thiserror       = {workspace = true}
 veryl-metadata  = {version = "0.5.5", path = "../metadata"}
 veryl-parser    = {version = "0.5.5", path = "../parser"}
+daggy           = "0.8.0"
 
 [dev-dependencies]
 toml = {workspace = true}

--- a/crates/analyzer/Cargo.toml
+++ b/crates/analyzer/Cargo.toml
@@ -20,6 +20,7 @@ thiserror       = {workspace = true}
 veryl-metadata  = {version = "0.5.5", path = "../metadata"}
 veryl-parser    = {version = "0.5.5", path = "../parser"}
 daggy           = "0.8.0"
+bimap         = "0.6.3"
 
 [dev-dependencies]
 toml = {workspace = true}

--- a/crates/analyzer/src/analyzer_error.rs
+++ b/crates/analyzer/src/analyzer_error.rs
@@ -425,7 +425,12 @@ impl AnalyzerError {
         )
     }
 
-    pub fn cyclic_type_dependency(source: &str, start: &str, end: &str, token: &VerylToken) -> Self {
+    pub fn cyclic_type_dependency(
+        source: &str,
+        start: &str,
+        end: &str,
+        token: &VerylToken,
+    ) -> Self {
         AnalyzerError::CyclicTypeDependency {
             start: start.into(),
             end: end.into(),

--- a/crates/analyzer/src/analyzer_error.rs
+++ b/crates/analyzer/src/analyzer_error.rs
@@ -7,6 +7,21 @@ use veryl_parser::veryl_token::VerylToken;
 pub enum AnalyzerError {
     #[diagnostic(
         severity(Error),
+        code(cyclice_type_dependency),
+        help(""),
+        url("https://dalance.github.io/veryl/book/06_appendix/02_semantic_error.html#cyclic_type_dependency")
+    )]
+    #[error("Cyclic dependency between {start} and {end}")]
+    CyclicTypeDependency {
+        start: String,
+        end: String,
+        #[source_code]
+        input: NamedSource,
+        #[label("Error location")]
+        error_location: SourceSpan,
+    },
+    #[diagnostic(
+        severity(Error),
         code(duplicated_identifier),
         help(""),
         url("https://dalance.github.io/veryl/book/06_appendix/02_semantic_error.html#duplicated_identifier")
@@ -408,6 +423,15 @@ impl AnalyzerError {
                 .to_string_lossy(),
             source.to_string(),
         )
+    }
+
+    pub fn cyclic_type_dependency(source: &str, start: &str, end: &str, token: &VerylToken) -> Self {
+        AnalyzerError::CyclicTypeDependency {
+            start: start.into(),
+            end: end.into(),
+            input: AnalyzerError::named_source(source, token),
+            error_location: token.token.into(),
+        }
     }
 
     pub fn duplicated_identifier(identifier: &str, source: &str, token: &VerylToken) -> Self {

--- a/crates/analyzer/src/handlers.rs
+++ b/crates/analyzer/src/handlers.rs
@@ -11,6 +11,7 @@ pub mod check_statement;
 pub mod check_system_function;
 pub mod create_reference;
 pub mod create_symbol_table;
+pub mod create_type_dag;
 use check_attribute::*;
 use check_direction::*;
 use check_enum::*;
@@ -28,6 +29,8 @@ use create_symbol_table::*;
 use crate::analyzer_error::AnalyzerError;
 use veryl_metadata::Lint;
 use veryl_parser::veryl_walker::Handler;
+
+use self::create_type_dag::CreateTypeDag;
 
 pub struct Pass1Handlers<'a> {
     check_attribute: CheckAttribute<'a>,
@@ -88,6 +91,7 @@ pub struct Pass2Handlers<'a> {
     check_instance: CheckInstance<'a>,
     check_msb_lsb: CheckMsbLsb<'a>,
     create_reference: CreateReference<'a>,
+    create_type_dag: CreateTypeDag<'a>,
 }
 
 impl<'a> Pass2Handlers<'a> {
@@ -99,6 +103,7 @@ impl<'a> Pass2Handlers<'a> {
             check_instance: CheckInstance::new(text),
             check_msb_lsb: CheckMsbLsb::new(text),
             create_reference: CreateReference::new(text),
+            create_type_dag: CreateTypeDag::new(text),
         }
     }
 
@@ -110,6 +115,7 @@ impl<'a> Pass2Handlers<'a> {
             &mut self.check_instance as &mut dyn Handler,
             &mut self.check_msb_lsb as &mut dyn Handler,
             &mut self.create_reference as &mut dyn Handler,
+            &mut self.create_type_dag as &mut dyn Handler,
         ]
     }
 
@@ -121,6 +127,7 @@ impl<'a> Pass2Handlers<'a> {
         ret.append(&mut self.check_instance.errors);
         ret.append(&mut self.check_msb_lsb.errors);
         ret.append(&mut self.create_reference.errors);
+        ret.append(&mut self.create_type_dag.errors);
         ret
     }
 }

--- a/crates/analyzer/src/handlers/create_type_dag.rs
+++ b/crates/analyzer/src/handlers/create_type_dag.rs
@@ -1,0 +1,142 @@
+use std::cell::RefCell;
+
+use veryl_parser::{veryl_token::VerylToken, resource_table, veryl_grammar_trait::{VerylGrammarTrait, StructUnionDeclaration, StructUnion, StructUnionItem, Identifier, TypeDefDeclaration, ScopedIdentifier, EnumDeclaration, VariableType, ScalarTypeGroup}, ParolError};
+use crate::{analyzer_error::AnalyzerError, symbol::Symbol, type_dag::{self }, symbol_table::{self, SymbolPathNamespace}};
+use veryl_parser::veryl_walker::{Handler, HandlerPoint};
+
+
+#[derive(Default)]
+pub struct CreateTypeDag<'a> {
+    text: &'a str,
+    pub errors: Vec<AnalyzerError>,
+    struct_or_union: Option<StructOrUnion>,
+    parent: Vec<Symbol>,
+    point: HandlerPoint,
+    in_type_def: bool,
+    in_enum_declaration: bool,
+    in_struct_union_declaration: bool,
+}
+
+
+#[derive(Clone)]
+enum StructOrUnion {
+    InStruct,
+    InUnion,
+}
+
+impl<'a> CreateTypeDag<'a> {
+    pub fn new(text: &'a str) -> Self {
+        Self {
+            text,
+            in_type_def: false,
+            in_enum_declaration: false,
+            ..Default::default()
+        }
+    }
+
+    fn insert_edge(&mut self, s: &Symbol, e: &Symbol) {
+        let start = resource_table::get_str_value(s.token.text).unwrap();
+        let end = resource_table::get_str_value(e.token.text).unwrap();
+        match type_dag::insert_edge(s, e) {
+            Ok(_) => {},
+            Err(er) => {
+                match er {
+                    type_dag::DagError::Cyclic(_, e) => {
+                        let token: VerylToken = VerylToken {
+                            token: e.token,
+                            comments: vec![],
+                        };
+                        self.errors.push(
+                            AnalyzerError::cyclic_type_dependency(
+                                self.text, &start, &end, &token)
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<'a> Handler for CreateTypeDag<'a> {
+    fn set_point(&mut self, p: HandlerPoint) {
+        self.point = p;
+    }
+}
+
+fn resolve_to_symbol<T: Into<SymbolPathNamespace>>(path: T) -> Option<Symbol> {
+    if let Ok(rr) = symbol_table::resolve(path) {
+        rr.found
+    } else {
+        None
+    }
+}
+
+impl<'a> VerylGrammarTrait for CreateTypeDag<'a> {
+    fn struct_union_declaration(&mut self, arg: &StructUnionDeclaration) -> Result<(), ParolError> {
+        match self.point {
+            HandlerPoint::Before => {
+                // Unused for now, but will be useful in the future
+                // to do this struct vs union chec
+                match &*arg.struct_union {
+                    StructUnion::Struct(_) =>
+                        self.struct_or_union = Some(StructOrUnion::InStruct),
+                    StructUnion::Union(_) =>
+                        self.struct_or_union = Some(StructOrUnion::InUnion),
+                }
+                self.parent.push(resolve_to_symbol(arg.identifier.as_ref()).unwrap());
+                self.in_struct_union_declaration = true;
+            }
+            HandlerPoint::After => {
+                self.parent.pop();
+                self.in_struct_union_declaration = false;
+            }
+        }
+        Ok(())
+    }
+
+    fn type_def_declaration(&mut self, arg: &TypeDefDeclaration) -> Result<(), ParolError> {
+        match self.point {
+            HandlerPoint::Before => {
+                self.parent.push(resolve_to_symbol(arg.identifier.as_ref()).unwrap());
+                self.in_type_def = true;
+            }
+            HandlerPoint::After => {
+                self.parent.pop();
+                self.in_type_def = false;
+            }
+        }
+        Ok(())
+    }
+
+    fn scoped_identifier(&mut self, arg: &ScopedIdentifier) -> Result<(), ParolError> {
+        if self.in_type_def |
+           self.in_enum_declaration |
+           self.in_struct_union_declaration {
+            if let HandlerPoint::Before = self.point {
+                let child = resolve_to_symbol(arg);
+                if let Some(child) = child {
+                    let parent = self.parent.last().unwrap().clone();
+                    self.insert_edge(&parent, &child);
+                } else {
+                    println!("Couldn't resolve scoped identifier");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn enum_declaration(&mut self, arg: &EnumDeclaration) -> Result<(), ParolError> {
+        match self.point {
+            HandlerPoint::Before => {
+                self.parent.push(resolve_to_symbol(arg.identifier.as_ref()).unwrap());
+                self.in_enum_declaration = true;
+            }
+            HandlerPoint::After => {
+                self.parent.pop();
+                self.in_enum_declaration = false;
+            }
+        }
+        Ok(())
+    }
+
+}

--- a/crates/analyzer/src/handlers/create_type_dag.rs
+++ b/crates/analyzer/src/handlers/create_type_dag.rs
@@ -1,10 +1,9 @@
 use crate::{
     analyzer_error::AnalyzerError,
-    symbol::Symbol,
-    symbol_table::{self, SymbolPathNamespace},
-    type_dag::{self},
+    symbol_table::SymbolPathNamespace,
+    type_dag::{self, Context, DagError, TypeResolveInfo},
 };
-use veryl_parser::veryl_walker::{Handler, HandlerPoint};
+use veryl_parser::{veryl_walker::{Handler, HandlerPoint}, veryl_grammar_trait::Identifier};
 use veryl_parser::{
     resource_table,
     veryl_grammar_trait::{
@@ -19,45 +18,61 @@ use veryl_parser::{
 pub struct CreateTypeDag<'a> {
     text: &'a str,
     pub errors: Vec<AnalyzerError>,
-    struct_or_union: Option<StructOrUnion>,
-    parent: Vec<Symbol>,
+    parent: Option<u32>,
     point: HandlerPoint,
-    in_type_def: bool,
-    in_enum_declaration: bool,
-    in_struct_union_declaration: bool,
-}
-
-#[derive(Clone)]
-enum StructOrUnion {
-    InStruct,
-    InUnion,
+    ctx: Context,
 }
 
 impl<'a> CreateTypeDag<'a> {
     pub fn new(text: &'a str) -> Self {
         Self {
             text,
-            in_type_def: false,
-            in_enum_declaration: false,
             ..Default::default()
         }
     }
 
-    fn insert_edge(&mut self, s: &Symbol, e: &Symbol) {
-        let start = resource_table::get_str_value(s.token.text).unwrap();
-        let end = resource_table::get_str_value(e.token.text).unwrap();
-        match type_dag::insert_edge(s, e) {
-            Ok(_) => {}
-            Err(er) => match er {
-                type_dag::DagError::Cyclic(_, e) => {
-                    let token: VerylToken = VerylToken {
-                        token: e.token,
-                        comments: vec![],
-                    };
-                    self.errors.push(AnalyzerError::cyclic_type_dependency(
-                        self.text, &start, &end, &token,
-                    ));
-                }
+    fn insert_node(&mut self, path: &SymbolPathNamespace, name: &str, token: &VerylToken) -> Option<u32> {
+        match type_dag::insert_node(path, &name, &token) {
+            Ok(n) => Some(n),
+            Err(e) => {
+                self.errors.push(self.to_analyzer_error(e));
+                None
+            },
+        }
+    }
+
+    fn to_analyzer_error(&self, de: DagError) -> AnalyzerError {
+match de {
+            DagError::Cyclic(s, e) => {
+                let token: VerylToken = VerylToken {
+                    token: e.token,
+                    comments: vec![],
+                };
+                let start = match resource_table::get_str_value(s.token.text,) {
+                    Some(s) => s,
+                    None => "<unknown StrId>".into(),
+                };
+                let end = match resource_table::get_str_value(e.token.text,) {
+                    Some(s) => s,
+                    None => "<unknown StrId>".into(),
+                };
+                AnalyzerError::cyclic_type_dependency(
+                    self.text, &start, &end, &token,
+                )
+            }
+            DagError::UnableToResolve(TypeResolveInfo
+                                      { path: _, name, token, }) => {
+                AnalyzerError::undefined_identifier(&name, self.text, &token)
+            }
+        }
+    }
+
+    fn insert_edge(&mut self, s: u32, e: u32, edge: Context) {
+        // Reversing this order to make traversal work
+        match type_dag::insert_edge(e, s, edge) {
+            Ok(_) => {},
+            Err(er) => {
+                self.errors.push(self.to_analyzer_error(er));
             },
         }
     }
@@ -69,31 +84,32 @@ impl<'a> Handler for CreateTypeDag<'a> {
     }
 }
 
-fn resolve_to_symbol<T: Into<SymbolPathNamespace>>(path: T) -> Option<Symbol> {
-    if let Ok(rr) = symbol_table::resolve(path) {
-        rr.found
-    } else {
-        None
-    }
-}
-
 impl<'a> VerylGrammarTrait for CreateTypeDag<'a> {
+    fn veryl(&mut self, _arg: &veryl_parser::veryl_grammar_trait::Veryl) -> Result<(), ParolError> {
+        if let HandlerPoint::After = self.point {
+            // Evaluate DAG
+
+        }
+        Ok(())
+    }
+
     fn struct_union_declaration(&mut self, arg: &StructUnionDeclaration) -> Result<(), ParolError> {
         match self.point {
             HandlerPoint::Before => {
+                let path: SymbolPathNamespace = arg.identifier.as_ref().into();
+                let name = arg.identifier.identifier_token.text();
+                let token = arg.identifier.identifier_token.clone();
+                self.parent  = self.insert_node(&path, &name, &token);
                 // Unused for now, but will be useful in the future
                 // to do this struct vs union chec
                 match &*arg.struct_union {
-                    StructUnion::Struct(_) => self.struct_or_union = Some(StructOrUnion::InStruct),
-                    StructUnion::Union(_) => self.struct_or_union = Some(StructOrUnion::InUnion),
+                    StructUnion::Struct(_) => self.ctx = Context::Struct,
+                    StructUnion::Union(_) => self.ctx = Context::Union,
                 }
-                self.parent
-                    .push(resolve_to_symbol(arg.identifier.as_ref()).unwrap());
-                self.in_struct_union_declaration = true;
             }
             HandlerPoint::After => {
-                self.parent.pop();
-                self.in_struct_union_declaration = false;
+                self.parent = None;
+                self.ctx = Context::Irrelevant;
             }
         }
         Ok(())
@@ -102,27 +118,36 @@ impl<'a> VerylGrammarTrait for CreateTypeDag<'a> {
     fn type_def_declaration(&mut self, arg: &TypeDefDeclaration) -> Result<(), ParolError> {
         match self.point {
             HandlerPoint::Before => {
-                self.parent
-                    .push(resolve_to_symbol(arg.identifier.as_ref()).unwrap());
-                self.in_type_def = true;
+                let path: SymbolPathNamespace = arg.identifier.as_ref().into();
+                let name = arg.identifier.identifier_token.text();
+                let token = arg.identifier.identifier_token.clone();
+                self.parent = self.insert_node(&path, &name, &token);
+                self.ctx = Context::TypeDef;
             }
             HandlerPoint::After => {
-                self.parent.pop();
-                self.in_type_def = false;
+                self.parent = None;
+                self.ctx = Context::TypeDef;
             }
         }
         Ok(())
     }
 
+
     fn scoped_identifier(&mut self, arg: &ScopedIdentifier) -> Result<(), ParolError> {
-        if self.in_type_def | self.in_enum_declaration | self.in_struct_union_declaration {
-            if let HandlerPoint::Before = self.point {
-                let child = resolve_to_symbol(arg);
-                if let Some(child) = child {
-                    let parent = self.parent.last().unwrap().clone();
-                    self.insert_edge(&parent, &child);
-                } else {
-                    println!("Couldn't resolve scoped identifier");
+        if let HandlerPoint::Before = self.point {
+            match self.ctx {
+                Context::Irrelevant => {},
+                _ => {
+                    let path: SymbolPathNamespace = arg.into();
+                    let name = to_string(arg);
+                    let token = arg.identifier.identifier_token.clone();
+                    let child = self.insert_node(&path, &name, &token);
+                    match (self.parent, child) {
+                        (Some(parent), Some(child)) => {
+                            self.insert_edge(parent, child, self.ctx);
+                        },
+                        _ => {}
+                    }
                 }
             }
         }
@@ -132,15 +157,35 @@ impl<'a> VerylGrammarTrait for CreateTypeDag<'a> {
     fn enum_declaration(&mut self, arg: &EnumDeclaration) -> Result<(), ParolError> {
         match self.point {
             HandlerPoint::Before => {
-                self.parent
-                    .push(resolve_to_symbol(arg.identifier.as_ref()).unwrap());
-                self.in_enum_declaration = true;
+                let path: SymbolPathNamespace = arg.identifier.as_ref().into();
+                let name = arg.identifier.identifier_token.text();
+                let token = arg.identifier.identifier_token.clone();
+                self.parent = self.insert_node(&path, &name, &token);
+                self.ctx = Context::Enum;
             }
             HandlerPoint::After => {
-                self.parent.pop();
-                self.in_enum_declaration = false;
+                self.parent = None;
+                self.ctx = Context::Irrelevant;
             }
         }
         Ok(())
     }
+}
+
+fn to_string(sid: &ScopedIdentifier) -> String {
+    let mut rv: String = "".into();
+
+    let f = |id: &Identifier, scope: bool| -> String {
+        let mut s: String = (if scope { "::" } else { "" }).into();
+        s.push_str(&id.identifier_token.text());
+        s
+    };
+    rv.push_str(&f(&sid.identifier, false));
+
+    for sidl in sid.scoped_identifier_list.iter() {
+        let id = sidl.identifier.as_ref();
+        rv.push_str(&f(id, true));
+    }
+
+    rv
 }

--- a/crates/analyzer/src/lib.rs
+++ b/crates/analyzer/src/lib.rs
@@ -8,5 +8,6 @@ pub mod namespace;
 pub mod namespace_table;
 pub mod symbol;
 pub mod symbol_table;
+pub mod type_dag;
 pub use analyzer::Analyzer;
 pub use analyzer_error::AnalyzerError;

--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -2,7 +2,7 @@ use crate::evaluator::{Evaluated, Evaluator};
 use crate::namespace::Namespace;
 use std::cell::{Cell, RefCell};
 use std::fmt;
-use veryl_parser::resource_table::{StrId};
+use veryl_parser::resource_table::StrId;
 use veryl_parser::veryl_grammar_trait as syntax_tree;
 use veryl_parser::veryl_token::Token;
 use veryl_parser::veryl_walker::VerylWalker;

--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -1,16 +1,30 @@
 use crate::evaluator::{Evaluated, Evaluator};
 use crate::namespace::Namespace;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::fmt;
-use veryl_parser::resource_table::StrId;
+use veryl_parser::resource_table::{StrId};
 use veryl_parser::veryl_grammar_trait as syntax_tree;
 use veryl_parser::veryl_token::Token;
 use veryl_parser::veryl_walker::VerylWalker;
 use veryl_parser::Stringifier;
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SymbolId(usize);
+
+thread_local!(static SYMBOL_ID: RefCell<usize> = RefCell::new(0));
+
+pub fn new_symbol_id() -> SymbolId {
+    SYMBOL_ID.with(|f| {
+        let mut ret = f.borrow_mut();
+        *ret += 1;
+        SymbolId(*ret)
+    })
+}
+
 #[derive(Debug, Clone)]
 pub struct Symbol {
     pub token: Token,
+    pub id: SymbolId,
     pub kind: SymbolKind,
     pub namespace: Namespace,
     pub references: Vec<Token>,
@@ -28,6 +42,7 @@ impl Symbol {
     ) -> Self {
         Self {
             token: *token,
+            id: new_symbol_id(),
             kind,
             namespace: namespace.to_owned(),
             references: Vec::new(),

--- a/crates/analyzer/src/symbol_table.rs
+++ b/crates/analyzer/src/symbol_table.rs
@@ -1,7 +1,7 @@
 use crate::evaluator::Evaluated;
 use crate::namespace::Namespace;
 use crate::namespace_table;
-use crate::symbol::{Direction, Symbol, SymbolKind, TypeKind, SymbolId};
+use crate::symbol::{Direction, Symbol, SymbolKind, TypeKind};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;

--- a/crates/analyzer/src/symbol_table.rs
+++ b/crates/analyzer/src/symbol_table.rs
@@ -1,7 +1,7 @@
 use crate::evaluator::Evaluated;
 use crate::namespace::Namespace;
 use crate::namespace_table;
-use crate::symbol::{Direction, Symbol, SymbolKind, TypeKind};
+use crate::symbol::{Direction, Symbol, SymbolKind, TypeKind, SymbolId};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
@@ -124,7 +124,7 @@ impl From<&syntax_tree::ExpressionIdentifier> for SymbolPath {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct SymbolPathNamespace(pub SymbolPath, pub Namespace);
 
 impl From<&Token> for SymbolPathNamespace {
@@ -207,6 +207,19 @@ impl SymbolTable {
         entry.push(symbol);
         true
     }
+
+    // fn update(&mut self, id: SymbolId, sym: Symbol,) -> Option<Symbol> {
+    //     for (_, symbols) in self.table.iter_mut() {
+    //         for symbol in symbols.iter_mut() {
+    //             if symbol.id == id {
+    //                 let rv = Some(sym);
+    //                 *symbol = sym;
+    //                 return rv;
+    //             }
+    //         }
+    //     }
+    //     None
+    // }
 
     pub fn get(
         &self,
@@ -436,6 +449,10 @@ pub fn resolve<T: Into<SymbolPathNamespace>>(path: T) -> Result<ResolveResult, R
     let SymbolPathNamespace(path, namespace) = path.into();
     SYMBOL_TABLE.with(|f| f.borrow().get(&path, &namespace))
 }
+
+// pub fn update(id: SymbolId, sym: Symbol) -> Option<Symbol> {
+//     SYMBOL_TABLE.with(|f| f.borrow_mut().update(id, sym));
+// }
 
 pub fn get_all() -> Vec<Symbol> {
     SYMBOL_TABLE.with(|f| f.borrow().get_all())

--- a/crates/analyzer/src/symbol_table.rs
+++ b/crates/analyzer/src/symbol_table.rs
@@ -208,19 +208,6 @@ impl SymbolTable {
         true
     }
 
-    // fn update(&mut self, id: SymbolId, sym: Symbol,) -> Option<Symbol> {
-    //     for (_, symbols) in self.table.iter_mut() {
-    //         for symbol in symbols.iter_mut() {
-    //             if symbol.id == id {
-    //                 let rv = Some(sym);
-    //                 *symbol = sym;
-    //                 return rv;
-    //             }
-    //         }
-    //     }
-    //     None
-    // }
-
     pub fn get(
         &self,
         path: &SymbolPath,
@@ -449,10 +436,6 @@ pub fn resolve<T: Into<SymbolPathNamespace>>(path: T) -> Result<ResolveResult, R
     let SymbolPathNamespace(path, namespace) = path.into();
     SYMBOL_TABLE.with(|f| f.borrow().get(&path, &namespace))
 }
-
-// pub fn update(id: SymbolId, sym: Symbol) -> Option<Symbol> {
-//     SYMBOL_TABLE.with(|f| f.borrow_mut().update(id, sym));
-// }
 
 pub fn get_all() -> Vec<Symbol> {
     SYMBOL_TABLE.with(|f| f.borrow().get_all())

--- a/crates/analyzer/src/type_dag.rs
+++ b/crates/analyzer/src/type_dag.rs
@@ -1,4 +1,4 @@
-use crate::{symbol::{Symbol, SymbolId}, AnalyzerError};
+use crate::symbol::{Symbol, SymbolId};
 use std::{cell::RefCell, collections::HashMap};
 
 use daggy::Dag;
@@ -36,8 +36,8 @@ impl TypeDag {
 
     fn insert_edge(&mut self, start: &Symbol, end: &Symbol) -> Result<(), DagError> {
         let s = self.insert_node(start);
-            let e = self.insert_node(end);
-            match self.dag.add_edge(s.into(), e.into(), ()) {
+        let e = self.insert_node(end);
+        match self.dag.add_edge(s.into(), e.into(), ()) {
             Ok(_) => Ok(()),
             Err(_) => Err(DagError::Cyclic(start.clone(), end.clone())),
         }

--- a/crates/analyzer/src/type_dag.rs
+++ b/crates/analyzer/src/type_dag.rs
@@ -1,0 +1,55 @@
+use crate::{symbol::{Symbol, SymbolId}, AnalyzerError};
+use std::{cell::RefCell, collections::HashMap};
+
+use daggy::Dag;
+
+#[derive(Debug, Default)]
+pub struct TypeDag {
+    dag: Dag<(), (), u32>,
+    /// Map between SymbolId and DAG NodeIdx
+    nodes: HashMap<SymbolId, u32>,
+}
+
+#[derive(Clone, Debug)]
+pub enum DagError {
+    Cyclic(Symbol, Symbol),
+}
+
+impl TypeDag {
+    #[allow(dead_code)]
+    fn new() -> Self {
+        Self {
+            dag: Dag::<(), (), u32>::new(),
+            nodes: HashMap::<SymbolId, u32>::new(),
+        }
+    }
+    fn insert_node(&mut self, sym: &Symbol) -> u32 {
+        match self.nodes.get(&sym.id) {
+            Some(node_idx) => *node_idx,
+            None => {
+                let node_idx = self.dag.add_node(()).index() as u32;
+                self.nodes.insert(sym.id, node_idx);
+                node_idx
+            }
+        }
+    }
+
+    fn insert_edge(&mut self, start: &Symbol, end: &Symbol) -> Result<(), DagError> {
+        let s = self.insert_node(start);
+            let e = self.insert_node(end);
+            match self.dag.add_edge(s.into(), e.into(), ()) {
+            Ok(_) => Ok(()),
+            Err(_) => Err(DagError::Cyclic(start.clone(), end.clone())),
+        }
+    }
+}
+
+thread_local!(static TYPE_DAG: RefCell<TypeDag> = RefCell::new(TypeDag::new()));
+
+pub fn insert_edge(start: &Symbol, end: &Symbol) -> Result<(), DagError> {
+    TYPE_DAG.with(|f| f.borrow_mut().insert_edge(start, end))
+}
+
+pub fn insert_node(start: &Symbol) -> u32 {
+    TYPE_DAG.with(|f| f.borrow_mut().insert_node(start))
+}

--- a/crates/analyzer/src/type_dag.rs
+++ b/crates/analyzer/src/type_dag.rs
@@ -1,55 +1,151 @@
-use crate::symbol::{Symbol, SymbolId};
+use crate::{symbol::{Symbol, SymbolId}, symbol_table::{SymbolPathNamespace, self}};
 use std::{cell::RefCell, collections::HashMap};
+use bimap::BiMap;
 
 use daggy::Dag;
+use veryl_parser::veryl_token::VerylToken;
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct TypeDag {
-    dag: Dag<(), (), u32>,
-    /// Map between SymbolId and DAG NodeIdx
-    nodes: HashMap<SymbolId, u32>,
+    dag: Dag<(), Context, u32>,
+    /// One-to-one relation between SymbolId and DAG NodeIdx
+    nodes: BiMap<SymbolId, u32>,
+    /// Map between NodeIdx and Symbol Resolve Information
+    paths: HashMap<u32, TypeResolveInfo>,
+    source: u32,
 }
 
 #[derive(Clone, Debug)]
+pub struct TypeResolveInfo {
+    pub path: SymbolPathNamespace,
+    pub name: String,
+    pub token: VerylToken,
+}
+
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
+pub enum Context {
+    Irrelevant,
+    Struct,
+    Union,
+    Enum,
+    TypeDef,
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Context::Irrelevant
+    }
+}
+
+#[derive(Debug, Clone)]
 pub enum DagError {
     Cyclic(Symbol, Symbol),
+    UnableToResolve(TypeResolveInfo),
 }
 
 impl TypeDag {
     #[allow(dead_code)]
     fn new() -> Self {
+        let mut dag = Dag::<(), Context, u32>::new();
+        let source = dag.add_node(()).index() as u32;
         Self {
-            dag: Dag::<(), (), u32>::new(),
-            nodes: HashMap::<SymbolId, u32>::new(),
+            dag,
+            nodes: BiMap::<SymbolId, u32>::new(),
+            paths: HashMap::<u32, TypeResolveInfo>::new(),
+            source,
         }
     }
-    fn insert_node(&mut self, sym: &Symbol) -> u32 {
-        match self.nodes.get(&sym.id) {
-            Some(node_idx) => *node_idx,
+
+    fn insert_node(&mut self, path: &SymbolPathNamespace, id: &str, token: &VerylToken) -> Result<u32, DagError> {
+        let trinfo = TypeResolveInfo {
+            path: path.clone(),
+            name: id.into(),
+            token: token.clone(),
+        };
+        let sym = match symbol_table::get(&trinfo.path.0, &trinfo.path.1) {
+            Ok(rr) => {
+                if let Some(sym) = rr.found {
+                    sym
+                } else {
+                    return Err(DagError::UnableToResolve(trinfo));
+                }
+            }
+            Err(_) => {
+                let e = DagError::UnableToResolve(trinfo);
+                return Err(e);
+            }
+        };
+        match self.nodes.get_by_left(&sym.id) {
+            Some(node_idx) => Ok(*node_idx),
             None => {
                 let node_idx = self.dag.add_node(()).index() as u32;
+                self.insert_edge(self.source, node_idx, Context::Irrelevant)?;
                 self.nodes.insert(sym.id, node_idx);
-                node_idx
+                self.paths.insert(node_idx, trinfo);
+                Ok(node_idx)
             }
         }
     }
 
-    fn insert_edge(&mut self, start: &Symbol, end: &Symbol) -> Result<(), DagError> {
-        let s = self.insert_node(start);
-        let e = self.insert_node(end);
-        match self.dag.add_edge(s.into(), e.into(), ()) {
-            Ok(_) => Ok(()),
-            Err(_) => Err(DagError::Cyclic(start.clone(), end.clone())),
+    fn get_symbol(&self, node: u32) -> Symbol {
+        match self.paths.get(&node) {
+            Some(TypeResolveInfo { path, .. }) => {
+                match symbol_table::get(&path.0, &path.1) {
+                    Ok(rr) => {
+                        match rr.found {
+                            Some(sym) => sym,
+                            None => { unreachable!(); }
+                        }
+                    }
+                    Err(_) => { unreachable!(); }
+                }
+            },
+            None => { panic!("Must insert node before accessing"); }
         }
     }
+
+    fn insert_edge(&mut self, start: u32, end: u32, edge: Context) -> Result<(), DagError> {
+        match self.dag.add_edge(start.into(), end.into(), edge) {
+            Ok(_) => Ok(()),
+            Err(_) => {
+                let ssym = self.get_symbol(start);
+                let esym = self.get_symbol(end);
+                Err(DagError::Cyclic(ssym, esym))
+            }
+        }
+    }
+
+    // fn evaluate(&self) {
+    //     fn rec_eval(td: &TypeDag, node: u32) -> Evaluated {
+    //         let nbors: Vec<(Context, u32)> = td.dag.children(
+    //             node.into()).iter(&td.dag)
+    //             .map(|(e, n)| (*td.dag.edge_weight(e).unwrap(), n.index() as u32))
+    //             .collect();
+    //         // Evaluate children
+    //         for (_, nbor) in nbors.iter() {
+    //             rec_eval(td, *nbor);
+    //         }
+    //         // Evaluate node
+    //         let node_sym = td.paths.get(&node).unwrap();
+    //         Evaluated::Unknown
+    //     }
+    // }
 }
 
 thread_local!(static TYPE_DAG: RefCell<TypeDag> = RefCell::new(TypeDag::new()));
 
-pub fn insert_edge(start: &Symbol, end: &Symbol) -> Result<(), DagError> {
-    TYPE_DAG.with(|f| f.borrow_mut().insert_edge(start, end))
+pub fn insert_edge(start: u32, end: u32, context: Context) -> Result<(), DagError> {
+    TYPE_DAG.with(|f| f.borrow_mut().insert_edge(start, end, context))
 }
 
-pub fn insert_node(start: &Symbol) -> u32 {
-    TYPE_DAG.with(|f| f.borrow_mut().insert_node(start))
+pub fn insert_node(start: &SymbolPathNamespace, id: &str, token:  &VerylToken) -> Result<u32, DagError> {
+    TYPE_DAG.with(|f| f.borrow_mut().insert_node(start, id, token))
+}
+
+// pub fn evaluate() {
+//     let dag = TYPE_DAG.with(|f| f.borrow_mut());
+// }
+
+pub fn get_symbol(node: u32) -> Symbol {
+    TYPE_DAG.with(|f| f.borrow().get_symbol(node))
 }

--- a/crates/analyzer/src/type_dag.rs
+++ b/crates/analyzer/src/type_dag.rs
@@ -1,6 +1,9 @@
-use crate::{symbol::{Symbol, SymbolId}, symbol_table::{SymbolPathNamespace, self}};
-use std::{cell::RefCell, collections::HashMap};
+use crate::{
+    symbol::{Symbol, SymbolId},
+    symbol_table::{self, SymbolPathNamespace},
+};
 use bimap::BiMap;
+use std::{cell::RefCell, collections::HashMap};
 
 use daggy::Dag;
 use veryl_parser::veryl_token::VerylToken;
@@ -56,7 +59,12 @@ impl TypeDag {
         }
     }
 
-    fn insert_node(&mut self, path: &SymbolPathNamespace, id: &str, token: &VerylToken) -> Result<u32, DagError> {
+    fn insert_node(
+        &mut self,
+        path: &SymbolPathNamespace,
+        id: &str,
+        token: &VerylToken,
+    ) -> Result<u32, DagError> {
         let trinfo = TypeResolveInfo {
             path: path.clone(),
             name: id.into(),
@@ -89,18 +97,20 @@ impl TypeDag {
 
     fn get_symbol(&self, node: u32) -> Symbol {
         match self.paths.get(&node) {
-            Some(TypeResolveInfo { path, .. }) => {
-                match symbol_table::get(&path.0, &path.1) {
-                    Ok(rr) => {
-                        match rr.found {
-                            Some(sym) => sym,
-                            None => { unreachable!(); }
-                        }
+            Some(TypeResolveInfo { path, .. }) => match symbol_table::get(&path.0, &path.1) {
+                Ok(rr) => match rr.found {
+                    Some(sym) => sym,
+                    None => {
+                        unreachable!();
                     }
-                    Err(_) => { unreachable!(); }
+                },
+                Err(_) => {
+                    unreachable!();
                 }
             },
-            None => { panic!("Must insert node before accessing"); }
+            None => {
+                panic!("Must insert node before accessing");
+            }
         }
     }
 
@@ -138,7 +148,11 @@ pub fn insert_edge(start: u32, end: u32, context: Context) -> Result<(), DagErro
     TYPE_DAG.with(|f| f.borrow_mut().insert_edge(start, end, context))
 }
 
-pub fn insert_node(start: &SymbolPathNamespace, id: &str, token:  &VerylToken) -> Result<u32, DagError> {
+pub fn insert_node(
+    start: &SymbolPathNamespace,
+    id: &str,
+    token: &VerylToken,
+) -> Result<u32, DagError> {
     TYPE_DAG.with(|f| f.borrow_mut().insert_node(start, id, token))
 }
 


### PR DESCRIPTION
This adds type checking for cyclic dependencies:

![image](https://github.com/dalance/veryl/assets/21023236/6f24eeb4-6bdb-491b-9fdb-0486ac524c74)



These dependencies are checked for `type` aliases, `struct`s and `union`s.

This is done with `CreateTypeDag` handler in Pass2.  It runs in Pass2 because it requires the symbol table made in Pass1.

Follow on work will be to add further type checking on type sizes.  This will go into Pass3, as it requires the [TypeDag] generated in Pass2. 