### PR TITLE
Checks that (module) inputs are only read

### DIFF
--- a/crates/analyzer/src/analyzer_error.rs
+++ b/crates/analyzer/src/analyzer_error.rs
@@ -7,6 +7,20 @@ use veryl_parser::veryl_token::VerylToken;
 pub enum AnalyzerError {
     #[diagnostic(
         severity(Error),
+        code(assignment_to_input),
+        help(""),
+        url("https://dalance.github.io/veryl/book/06_appendix/02_semantic_error.html#assignment_to_input")
+    )]
+    #[error("Assignment to input {identifier}")]
+    AssignmentToInput {
+        identifier: String,
+        #[source_code]
+        input: NamedSource,
+        #[label("Error location")]
+        error_location: SourceSpan,
+    },
+    #[diagnostic(
+        severity(Error),
         code(cyclice_type_dependency),
         help(""),
         url("https://dalance.github.io/veryl/book/06_appendix/02_semantic_error.html#cyclic_type_dependency")
@@ -34,7 +48,20 @@ pub enum AnalyzerError {
         #[label("Error location")]
         error_location: SourceSpan,
     },
-
+    #[diagnostic(
+        severity(Error),
+        code(duplicated_assignment),
+        help(""),
+        url("https://dalance.github.io/veryl/book/06_appendix/02_semantic_error.html#duplicated_assignment")
+    )]
+    #[error("{identifier} is assigned in multiple procedural blocks or assignment statements")]
+    DuplicatedAssignment {
+        identifier: String,
+        #[source_code]
+        input: NamedSource,
+        #[label("Error location")]
+        error_location: SourceSpan,
+    },
     #[diagnostic(
         severity(Error),
         code(invalid_allow),
@@ -425,6 +452,14 @@ impl AnalyzerError {
         )
     }
 
+    pub fn assignment_to_input(source: &str, identifier: &str, token: &VerylToken) -> Self {
+        AnalyzerError::AssignmentToInput {
+            identifier: identifier.into(),
+            input: AnalyzerError::named_source(source, token),
+            error_location: token.token.into(),
+        }
+    }
+
     pub fn cyclic_type_dependency(
         source: &str,
         start: &str,
@@ -441,6 +476,14 @@ impl AnalyzerError {
 
     pub fn duplicated_identifier(identifier: &str, source: &str, token: &VerylToken) -> Self {
         AnalyzerError::DuplicatedIdentifier {
+            identifier: identifier.to_string(),
+            input: AnalyzerError::named_source(source, token),
+            error_location: token.token.into(),
+        }
+    }
+
+    pub fn duplicated_assignment(identifier: &str, source: &str, token: &VerylToken) -> Self {
+        AnalyzerError::DuplicatedAssignment {
             identifier: identifier.to_string(),
             input: AnalyzerError::named_source(source, token),
             error_location: token.token.into(),

--- a/crates/analyzer/src/handlers.rs
+++ b/crates/analyzer/src/handlers.rs
@@ -4,6 +4,7 @@ pub mod check_enum;
 pub mod check_function;
 pub mod check_identifier;
 pub mod check_instance;
+pub mod check_module;
 pub mod check_msb_lsb;
 pub mod check_number;
 pub mod check_reset;
@@ -30,7 +31,7 @@ use crate::analyzer_error::AnalyzerError;
 use veryl_metadata::Lint;
 use veryl_parser::veryl_walker::Handler;
 
-use self::create_type_dag::CreateTypeDag;
+use self::{check_module::CheckModule, create_type_dag::CreateTypeDag};
 
 pub struct Pass1Handlers<'a> {
     check_attribute: CheckAttribute<'a>,
@@ -90,6 +91,7 @@ pub struct Pass2Handlers<'a> {
     check_function: CheckFunction<'a>,
     check_instance: CheckInstance<'a>,
     check_msb_lsb: CheckMsbLsb<'a>,
+    check_module: CheckModule<'a>,
     create_reference: CreateReference<'a>,
     create_type_dag: CreateTypeDag<'a>,
 }
@@ -102,6 +104,7 @@ impl<'a> Pass2Handlers<'a> {
             check_function: CheckFunction::new(text),
             check_instance: CheckInstance::new(text),
             check_msb_lsb: CheckMsbLsb::new(text),
+            check_module: CheckModule::new(text),
             create_reference: CreateReference::new(text),
             create_type_dag: CreateTypeDag::new(text),
         }
@@ -114,6 +117,7 @@ impl<'a> Pass2Handlers<'a> {
             &mut self.check_function as &mut dyn Handler,
             &mut self.check_instance as &mut dyn Handler,
             &mut self.check_msb_lsb as &mut dyn Handler,
+            &mut self.check_module as &mut dyn Handler,
             &mut self.create_reference as &mut dyn Handler,
             &mut self.create_type_dag as &mut dyn Handler,
         ]
@@ -126,6 +130,7 @@ impl<'a> Pass2Handlers<'a> {
         ret.append(&mut self.check_function.errors);
         ret.append(&mut self.check_instance.errors);
         ret.append(&mut self.check_msb_lsb.errors);
+        ret.append(&mut self.check_module.errors);
         ret.append(&mut self.create_reference.errors);
         ret.append(&mut self.create_type_dag.errors);
         ret

--- a/crates/analyzer/src/handlers/check_module.rs
+++ b/crates/analyzer/src/handlers/check_module.rs
@@ -1,0 +1,163 @@
+use crate::analyzer_error::AnalyzerError;
+use crate::symbol::{Symbol, SymbolId};
+use crate::symbol_table::{self};
+use veryl_parser::veryl_token::VerylToken;
+use veryl_parser::veryl_walker::{Handler, HandlerPoint};
+use veryl_parser::ParolError;
+use veryl_parser::{resource_table, veryl_grammar_trait::*};
+
+pub struct CheckModule<'a> {
+    pub errors: Vec<AnalyzerError>,
+    text: &'a str,
+    point: HandlerPoint,
+    inputs: Vec<(SymbolId, u32)>,
+    block_record: Vec<SymbolId>,
+    in_if_for_depth: u32,
+    in_module: bool,
+}
+
+impl<'a> CheckModule<'a> {
+    pub fn new(text: &'a str) -> Self {
+        Self {
+            errors: Vec::new(),
+            text,
+            point: HandlerPoint::Before,
+            inputs: vec![],
+            block_record: vec![],
+            in_if_for_depth: 0,
+            in_module: false,
+        }
+    }
+
+    fn assign_check_inputs(&mut self, symb: &Symbol, token: &VerylToken) {
+        if self
+            .inputs
+            .binary_search_by(|probe| probe.0.cmp(&symb.id))
+            .is_ok()
+        {
+            let identifier = resource_table::get_str_value(symb.token.text).unwrap();
+            self.errors.push(AnalyzerError::assignment_to_input(
+                self.text,
+                &identifier,
+                token,
+            ));
+        }
+    }
+}
+
+impl<'a> Handler for CheckModule<'a> {
+    fn set_point(&mut self, p: HandlerPoint) {
+        self.point = p;
+    }
+}
+
+impl<'a> VerylGrammarTrait for CheckModule<'a> {
+    fn module_declaration(&mut self, _arg: &ModuleDeclaration) -> Result<(), ParolError> {
+        match self.point {
+            HandlerPoint::Before => {
+                self.in_module = true;
+            }
+            HandlerPoint::After => {
+                self.in_module = false;
+            }
+        }
+        Ok(())
+    }
+
+    fn always_comb_declaration(&mut self, _arg: &AlwaysCombDeclaration) -> Result<(), ParolError> {
+        if let HandlerPoint::Before = self.point {
+            self.block_record.clear();
+        }
+        Ok(())
+    }
+
+    fn always_ff_declaration(&mut self, _arg: &AlwaysFfDeclaration) -> Result<(), ParolError> {
+        if let HandlerPoint::Before = self.point {
+            self.block_record.clear();
+        }
+        Ok(())
+    }
+
+    fn function_declaration(&mut self, _arg: &FunctionDeclaration) -> Result<(), ParolError> {
+        if let HandlerPoint::Before = self.point {
+            self.block_record.clear();
+        }
+        Ok(())
+    }
+
+    fn identifier_statement(&mut self, arg: &IdentifierStatement) -> Result<(), ParolError> {
+        if self.in_module {
+            if let HandlerPoint::Before = self.point {
+                if let IdentifierStatementGroup::Assignment(_) = &*arg.identifier_statement_group {
+                    let symb = symbol_table::resolve(arg.expression_identifier.as_ref()).unwrap();
+                    let symb = symb.found.unwrap();
+                    let token = &arg.expression_identifier.identifier.identifier_token;
+                    self.assign_check_inputs(&symb, token);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn port_declaration_item(&mut self, arg: &PortDeclarationItem) -> Result<(), ParolError> {
+        if !self.in_module {
+            return Ok(());
+        }
+        if let HandlerPoint::Before = self.point {
+            match &*arg.port_declaration_item_group {
+                PortDeclarationItemGroup::DirectionArrayType(x) => {
+                    let id = match symbol_table::resolve(arg.identifier.as_ref()) {
+                        Ok(x) => x.found.unwrap().id,
+                        Err(_) => panic!(),
+                    };
+                    if let Direction::Input(_) = &*x.direction {
+                        self.inputs.push((id, 0));
+                    }
+                    // TODO: Cover Inout, Ref, Outputs, and Modports for checking
+                }
+                // TODO: Support Interface output checking
+                PortDeclarationItemGroup::InterfacePortDeclarationItemOpt(_) => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn assign_declaration(&mut self, arg: &AssignDeclaration) -> Result<(), ParolError> {
+        if self.in_module {
+            if let HandlerPoint::Before = self.point {
+                let symb = match symbol_table::resolve(arg.hierarchical_identifier.as_ref()) {
+                    Ok(x) => x.found.unwrap(),
+                    Err(_) => panic!(),
+                };
+                let token = &arg.hierarchical_identifier.identifier.identifier_token;
+                self.assign_check_inputs(&symb, token);
+            }
+        }
+        Ok(())
+    }
+
+    fn module_if_declaration(&mut self, _arg: &ModuleIfDeclaration) -> Result<(), ParolError> {
+        match self.point {
+            HandlerPoint::Before => self.in_if_for_depth += 1,
+            HandlerPoint::After => self.in_if_for_depth -= 1,
+        }
+        Ok(())
+    }
+
+    fn module_for_declaration(&mut self, _arg: &ModuleForDeclaration) -> Result<(), ParolError> {
+        match self.point {
+            HandlerPoint::Before => self.in_if_for_depth += 1,
+            HandlerPoint::After => self.in_if_for_depth -= 1,
+        }
+        Ok(())
+    }
+
+    fn port_declaration_list(&mut self, _arg: &PortDeclarationList) -> Result<(), ParolError> {
+        if self.in_module {
+            if let HandlerPoint::After = self.point {
+                self.inputs.sort();
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/analyzer/src/symbol.rs
+++ b/crates/analyzer/src/symbol.rs
@@ -9,7 +9,7 @@ use veryl_parser::veryl_walker::VerylWalker;
 use veryl_parser::Stringifier;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct SymbolId(usize);
+pub struct SymbolId(pub usize);
 
 thread_local!(static SYMBOL_ID: RefCell<usize> = RefCell::new(0));
 


### PR DESCRIPTION
This commit checks that module inputs are read-only.

Attempts to assign a value to an input, either via an assignment statement or in a procedural block, will result in an `assignment_to_input` error.