### PR TITLE
Fix inside/outside precedence issue

### DIFF
--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -790,8 +790,9 @@ impl VerylWalker for Emitter {
 
     /// Semantic action for non-terminal 'InsideExpression'
     fn inside_expression(&mut self, arg: &InsideExpression) {
-        self.str("(");
+        self.str("((");
         self.expression(&arg.expression);
+        self.str(")");
         self.space(1);
         self.inside(&arg.inside);
         self.space(1);
@@ -803,8 +804,9 @@ impl VerylWalker for Emitter {
 
     /// Semantic action for non-terminal 'OutsideExpression'
     fn outside_expression(&mut self, arg: &OutsideExpression) {
-        self.str("!(");
+        self.str("!((");
         self.expression(&arg.expression);
+        self.str(")");
         self.space(1);
         self.token(&arg.outside.outside_token.replace("inside"));
         self.space(1);

--- a/testcases/sv/32_inside_outside.sv
+++ b/testcases/sv/32_inside_outside.sv
@@ -2,6 +2,6 @@ module veryl_testcase_Module32;
     logic a;
     logic b;
 
-    assign a = (1 + 2 / 3 inside {0, [0:(10)-1], [1:10]});
-    assign b = !(1 * 2 - 1 inside {0, [0:(10)-1], [1:10]});
+    assign a = ((1 + 2 / 3) inside {0, [0:(10)-1], [1:10]});
+    assign b = !((1 * 2 - 1) inside {0, [0:(10)-1], [1:10]});
 endmodule


### PR DESCRIPTION
`()` is required because `inside`/`outside` has lower precedence than some operators.